### PR TITLE
Avoid mutating 'times' array on sort

### DIFF
--- a/src/components/timeTable/TimeTable.js
+++ b/src/components/timeTable/TimeTable.js
@@ -51,7 +51,7 @@ const TimeTable = ({
   const { includedIds = [], excludedIds = [] } = highlightedStat[highlightedStatType] || {};
 
   const getSolveIndex = index => (showLatestSolveOnTop ? times.length - 1 - index : index);
-  const sortedTimes = showLatestSolveOnTop ? times.sort(createDescSorter('date')) : times;
+  const sortedTimes = showLatestSolveOnTop ? [...times].sort(createDescSorter('date')) : times;
 
   return (
     <TimeTableContainer>


### PR DESCRIPTION
Hello,
Realised I made a mistake in previous PR! `sort` mutates the original array which means if the user switches the setting without refreshing the page, odd things can happen.

Small update to fix the bug.